### PR TITLE
Skip rows with missing values and add annotation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PairPlots"
 uuid = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 authors = ["William Thompson <wthompson@uvic.ca>"]
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
@@ -11,6 +11,7 @@ Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PolygonOps = "647866c9-e3ac-4575-94e7-e3d426903924"

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]

--- a/src/PairPlots.jl
+++ b/src/PairPlots.jl
@@ -721,16 +721,25 @@ function pairplot(
     # Add a bottom annotation listing the count of rows skipped for missing data by series
     # We want each annotation on a separate line. But we can't use Base.join() for
     # Makie.rich text... Need to do it ourselves.
-    for (i,(missing_count, series)) in enumerate(zip(missing_counts, pairs_no_missing))
+    for (i,(missing_count, (series,viz))) in enumerate(zip(missing_counts, pairs_no_missing))
         # If there is only one series, we don't have mention it by name in the text annotation.
         if length(pairs_no_missing) == 1
             missing_text = Makie.rich("$missing_count rows with missing values are hidden.")
         else
-            label = series[1].label
+            label = series.label
             if isnothing(label)
                 label = "$i"
             end
-            missing_text = Makie.rich("$missing_count rows with missing values are hidden from series $label.")
+            kwargs = (;)
+            if haskey(series.kwargs, :color)
+                color = series.kwargs[:color]
+                if color isa Tuple
+                    # Don't pass transparency into the label
+                    color = color[1]
+                end
+                kwargs = (;color)
+            end
+            missing_text = Makie.rich("$missing_count rows with missing values are hidden from series $label."; kwargs...)
         end
         # Add an annotation to the bottom listing the counts of missin values that
         # were skipped.


### PR DESCRIPTION
Address the feature request in  #25.
Skips all samples/rows that contain any missing values and report the number skipped in an annotation at the bottom.

This is perhaps a bit conservative since I could imagine that in some cases, a user might want to still see a sample in the plots where the column values aren't nothing. 
Let's wait until we get a complaint to address such an option.

Example:
```julia
df = DataFrame(randn(1000,3) .* rand.(Ref((missing, 1, 1, 1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1))), :auto)
pairplot(df)
```
<img width="328" alt="image" src="https://github.com/sefffal/PairPlots.jl/assets/7330605/79e0a9bf-2202-43fe-8a75-7da82afad431">


Example with multiple series:
```julia
df1 = DataFrame(randn(1000,3) .* rand.(Ref((missing, 1, 1, 1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1))), :auto)
df2 = DataFrame(randn(1000,3) .* rand.(Ref((missing, 1, 1, 1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1))), :auto)
pairplot(
    PairPlots.Series(df1,label="two",color=:blue),
    PairPlots.Series(df2,label="one",color=(:red,0.5))
)
```
<img width="387" alt="image" src="https://github.com/sefffal/PairPlots.jl/assets/7330605/a061ce08-d303-4e44-a731-afbb4bfb4f19">

