### PR TITLE
Improve default formatter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PairPlots"
 uuid = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 authors = ["William Thompson <wthompson@uvic.ca>"]
-version = "2.3.1"
+version = "2.4.0"
 
 [deps]
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"


### PR DESCRIPTION
@astrozot Here is my first pass at solving #37. I used the snippet you provided to calculate the number of decimal points to display. Once it exceeds 5, I find it too hard to read the number of zeros at a glance, and so it switches to scientific notation. 

Take a look at these two examples and let me know what you think.

<img width="677" alt="image" src="https://github.com/sefffal/PairPlots.jl/assets/7330605/4df45237-a36f-47dd-b52c-5f64b209cc72">
<img width="677" alt="image" src="https://github.com/sefffal/PairPlots.jl/assets/7330605/035ec9e5-f179-4b6c-a982-dabd16768178">


Maybe this is enough without additional per variable customization, since users can always just reach into the figure and set manual labels, eg.
```
fig = pairplot(df)
fig.content[1].title[] = "ABC"
fig
```