### PR TITLE
Fixes for DocumenterVitepress v0.2

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,3 +7,6 @@ MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 PairPlots = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+DocumenterVitepress = ">= 0.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ makedocs(
 )
 
 
-deploydocs(
+DocumenterVitepress.deploydocs(
     repo = "github.com/sefffal/PairPlots.jl.git",
     devbranch = "master",
     push_preview = true


### PR DESCRIPTION
DV now has its own deploydocs to get around Vitepress issues, that's the only user visible change really.  But things should be a lot more stable with less 404's.