### PR TITLE
Add default colour when plotting directly with Series

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PairPlots"
 uuid = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 authors = ["William Thompson <wthompson@uvic.ca>"]
-version = "3.0.3"
+version = "3.0.4"
 
 [deps]
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"

--- a/src/PairPlots.jl
+++ b/src/PairPlots.jl
@@ -618,6 +618,18 @@ function pairplot(
         linestyle = linestyles[1+div(series_i-1, length(wc))] # if running out of colors
         return Series(dat; color, bottomleft, topright, bins, strokecolor=color#=, linestyle=#) # TODO: not all series (e.g. Scatter) support linestyle attribute
     end
+    function SeriesDefaults(series::Series)
+        # Add default color to the series if not specified
+        series_i += 1
+        return if !(haskey(series.kwargs, :color)) && !(haskey(series.kwargs, :strokecolor))
+            wc = Makie.wong_colors()
+            color = wc[mod1(series_i, length(wc))]
+            new_kwargs = (color=color, strokecolor=color, series.kwargs...)
+            Series(series.label, series.table, series.bottomleft, series.topright, series.bins, new_kwargs)
+        else
+            series
+        end
+    end
 
     countser((data,vizlayers)::Pair) = countser(data)
     countser(series::Series) = 1
@@ -634,14 +646,14 @@ function pairplot(
         return pairplot(grid, map(defaults1, datapairs)...; kwargs...)
     elseif len_datapairs_not_truth <= 5
         defaults_upto5((data,vizlayers)::Pair) = SeriesDefaults(data) => vizlayers
-        defaults_upto5(series::Series) = series => multi_series_default_viz
+        defaults_upto5(series::Series) = SeriesDefaults(series) => multi_series_default_viz
         defaults_upto5(truths::Truth) = truths => truths_default_viz
 		defaults_upto5(bands::Band) = bands => bands_default_viz
         defaults_upto5(data::Any) = SeriesDefaults(data) => multi_series_default_viz
         return pairplot(grid, map(defaults_upto5, datapairs)...; kwargs...)
     else # More than 5 series
         defaults_morethan5((data,vizlayers)::Pair) = SeriesDefaults(data) => vizlayers
-        defaults_morethan5(series::Series) = series => many_series_default_viz
+        defaults_morethan5(series::Series) = SeriesDefaults(series) => many_series_default_viz
         defaults_morethan5(truths::Truth) = truths => truths_default_viz
 		defaults_morethan5(bands::Band) = bands => bands_default_viz
         defaults_morethan5(data::Any) = SeriesDefaults(data) => many_series_default_viz


### PR DESCRIPTION
Let's say I have multiple different sources of data but I want to give them labels. I think the recommended way to do this is to create a `Series` myself with a label:

```julia
using PairPlots, CairoMakie

d1 = (x = randn(10), y = randn(10))
d2 = (x = randn(10), y = randn(10))

pairplot(PairPlots.Series(d1; label="d1"), PairPlots.Series(d2; label="d2"))
```

<img width="968" height="906" alt="main" src="https://github.com/user-attachments/assets/6b653903-e2f3-417f-9555-acbcc540b570" />

This is a perfectly pretty plot! But the legend, and the subplot titles, are in black instead of the blue and yellow. I'm aware that I can explicitly specify `color=...` but I'd like the default colours to be used when I don't specify anything. (Indeed, that is exactly what happens when using `pairplot(d1, d2)` directly.)

-----

This PR fixes that by passing `Series` arguments through the `SeriesDefaults` constructor, just like any other data, which will assign the same default colour to the `Series` if the user has not specified one themselves.

With this PR, the same code above gives:

<img width="968" height="906" alt="PR" src="https://github.com/user-attachments/assets/f0e2b8f2-1b2f-4454-85ad-7a29eec2f04e" />
